### PR TITLE
Master

### DIFF
--- a/lib/jdvp-codetabs-commonmark.rb
+++ b/lib/jdvp-codetabs-commonmark.rb
@@ -12,8 +12,8 @@ class CodeTabsCustomerRenderer < JekyllCommonMarkCustomRenderer
       if (!@added_assets_links)
         #Add references to the fonts, css, and js required
         out("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Roboto+Mono\"/>")
-        out("<link rel=\"stylesheet\" href=\"assets/codeblock.css\"/>")
-        out("<script src=\"assets/codeblock.js\"></script>")
+        out("<link rel=\"stylesheet\" href=\"/assets/codeblock.css\"/>")
+        out("<script src=\"/assets/codeblock.js\"></script>")
         @added_assets_links = true
       end
     end


### PR DESCRIPTION
Hi,
Installed as it, the assets files reference in each html page outputed in _sites points to the post folder instead of the root.
I added a few "/".
Tested and works great now, thanks for this cool gem