### PR TITLE
#4 : Only add links to the codeblock CSS and JS in files where it is needed

### DIFF
--- a/jdvp-codetabs-commonmark.gemspec
+++ b/jdvp-codetabs-commonmark.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "jdvp-codetabs-commonmark"
   spec.summary       = "CommonMark generator for Jekyll that adds tabbed code functionality"
-  spec.version       = "0.1.3"
+  spec.version       = "0.1.4"
   spec.authors       = ["JD Porterfield"]
   spec.email         = "jd.porterfield@alumni.rice.edu"
   spec.homepage      = "https://github.com/jdvp/jdvp-codetabs-commonmark"

--- a/lib/jdvp-codetabs-commonmark.rb
+++ b/lib/jdvp-codetabs-commonmark.rb
@@ -144,6 +144,18 @@ class Jekyll::Converters::Markdown
   end
 end
 
+Jekyll::Hooks.register :documents, :post_convert do |post|
+  if post.content.include? "JdvpCodeTabs-baseurl"
+    post.content = post.content.gsub("JdvpCodeTabs-baseurl", "#{post.site.baseurl}")
+  end
+end
+
+Jekyll::Hooks.register :pages, :post_convert do |post|
+  if post.content.include? "JdvpCodeTabs-baseurl"
+    post.content = post.content.gsub("JdvpCodeTabs-baseurl", "#{post.site.baseurl}")
+  end
+end
+
 Jekyll::Hooks.register :posts, :post_convert do |post|
   if post.content.include? "JdvpCodeTabs-baseurl"
     post.content = post.content.gsub("JdvpCodeTabs-baseurl", "#{post.site.baseurl}")

--- a/lib/jdvp-codetabs-commonmark.rb
+++ b/lib/jdvp-codetabs-commonmark.rb
@@ -158,7 +158,6 @@ def add_resource_links_in_html_head(site)
   end
 end
 
-
 #After the site is written, the necessary files this plugin's generateed code needs are also written
 Jekyll::Hooks.register :site, :post_write do |site|
   #Copy CSS required for code tabs

--- a/lib/jdvp-codetabs-commonmark.rb
+++ b/lib/jdvp-codetabs-commonmark.rb
@@ -4,21 +4,7 @@ require "jekyll"
 require "securerandom"
 
 class CodeTabsCustomerRenderer < JekyllCommonMarkCustomRenderer
-  @added_assets_links = false
   @added_copy_snackbar = false
-
-  def render(node)
-    if node.type == :document
-      if (!@added_assets_links)
-        #Add references to the fonts, css, and js required
-        out("<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Roboto+Mono\"/>")
-        out("<link rel=\"stylesheet\" href=\"JdvpCodeTabs-baseurl/assets/codeblock.css\"/>")
-        out("<script src=\"JdvpCodeTabs-baseurl/assets/codeblock.js\"></script>")
-        @added_assets_links = true
-      end
-    end
-    super(node)
-  end
 
   def code_block(node)
     #Determine what objects this code block is surrounded by.
@@ -144,23 +130,34 @@ class Jekyll::Converters::Markdown
   end
 end
 
-Jekyll::Hooks.register :documents, :post_convert do |post|
-  if post.content.include? "JdvpCodeTabs-baseurl"
-    post.content = post.content.gsub("JdvpCodeTabs-baseurl", "#{post.site.baseurl}")
+def get_resource_string(site)
+ return "<link rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css?family=Roboto+Mono\"/>" +
+        "<link rel=\"stylesheet\" href=\"#{site.baseurl}/assets/codeblock.css\"/>" +
+        "<script src=\"#{site.baseurl}/assets/codeblock.js\"></script>"
+end
+
+def add_resource_links_in_html_head(site)
+  site_directory = "#{site.in_dest_dir("/")}"
+
+  # For every html file in the generated site 
+  Dir.glob("*.html", base: site_directory).each do |file_name|
+    file_plus_path = "#{site_directory}#{file_name}"
+
+    # Check if the file contains a code switcher and skip it if it does not
+    if (!File.foreach(file_plus_path).grep(/code_switcher_container_parent/).any?)
+      next
+    end
+
+    # If the file has a code switcher and a head element, add the resource links to the end of the head element
+    if (File.foreach(file_plus_path).grep(/<\/head>/).any?)
+      File.write(file_plus_path, File.open(file_plus_path, &:read).sub("</head>","#{get_resource_string(site)}</head>"))
+    # Otherwise if it has a html element add a head element with the resource links
+    elsif (File.foreach(file_plus_path).grep(/<\/html>/).any?)
+      File.write(file_plus_path, File.open(file_plus_path, &:read).sub(/(<html.*>)/,"#{$1}<head>#{get_resource_string(site)}</head>"))
+    end
   end
 end
 
-Jekyll::Hooks.register :pages, :post_convert do |post|
-  if post.content.include? "JdvpCodeTabs-baseurl"
-    post.content = post.content.gsub("JdvpCodeTabs-baseurl", "#{post.site.baseurl}")
-  end
-end
-
-Jekyll::Hooks.register :posts, :post_convert do |post|
-  if post.content.include? "JdvpCodeTabs-baseurl"
-    post.content = post.content.gsub("JdvpCodeTabs-baseurl", "#{post.site.baseurl}")
-  end
-end
 
 #After the site is written, the necessary files this plugin's generateed code needs are also written
 Jekyll::Hooks.register :site, :post_write do |site|
@@ -178,4 +175,7 @@ Jekyll::Hooks.register :site, :post_write do |site|
   FileUtils.cp(copy_icon, "#{site.in_dest_dir("assets/icon_copy.svg")}")
   theme_icon = File.expand_path("../../assets/icon_theme.svg", __FILE__)
   FileUtils.cp(theme_icon, "#{site.in_dest_dir("assets/icon_theme.svg")}")
+
+  #Add CSS & JS references to files that use code tabs
+  add_resource_links_in_html_head(site)
 end


### PR DESCRIPTION
feat : By doing so, we eliminate a small amount of data usage per page
when it isn't necessary. This commit ensures that the CSS and JS links are added into the <head>
element in the HTML. This ensures they aren't picked up by things such as
post.excerpt.